### PR TITLE
Adding 2fa API

### DIFF
--- a/Managers/SmsManager.php
+++ b/Managers/SmsManager.php
@@ -45,6 +45,18 @@ class SmsManager
         return SmsSendResponse::createFromResponse($response);
     }
 
+    /**
+     * @param string $number
+     * @param string $pin
+     * @param int $client_ref
+     * @return SmsSendResponse
+     */
+    public function send2fa($number,$pin,$client_ref=false) {
+        $number = PhoneNumber::prefixFilter($number);
+        $response = $this->nexmoClient->send2faMessage($number,$pin,$client_ref);
+        return SmsSendResponse::createFromResponse($response);
+    }
+
     public function sendBinary() {
         throw new \Exception(__METHOD__.' not yet implemented');
     }


### PR DESCRIPTION
#### What does this PR do?

Implements the API documented on this page https://docs.nexmo.com/api-ref/us-shared-short-code-api/two-factor-authentication

#### How should this be manually tested?

First, create a short code and message template according to the docs above.
Then, Instead of the `sendText` method, use the `send2fa` method, i.e.:

`$this->smsManager->send2fa($destinationPhoneNumber,$pin);`

"From Name" is not apparently supported or required with the 2fa API.

#### What are the deployment instructions (if any?)

Might want to create a readme line referring to this new API endpoint and double-check my work; I don't really know what I'm doing, just need to send 2fa messages to US recipients. 
It does appear to mostly work according to the Nexmo web interface, although for some reason I'm not actually getting messages on my test phone.