### PR TITLE
Valid YAML configuration files PhpUnit 5 and Symfony 3

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,16 +1,16 @@
 services:
     jhg_nexmo_client:
         class: Jhg\NexmoBundle\NexmoClient\NexmoClient
-        arguments: ["%jhg_nexmo.api_key%","%jhg_nexmo.api_secret%","%jhg_nexmo.api_method%","%jhg_nexmo.delivery_phone%","%jhg_nexmo.disable_delivery%",@logger]
+        arguments: ['%jhg_nexmo.api_key%', '%jhg_nexmo.api_secret%', '%jhg_nexmo.api_method%', '%jhg_nexmo.delivery_phone%' ,'%jhg_nexmo.disable_delivery%', '@logger']
 
     jhg_nexmo_account:
         class: Jhg\NexmoBundle\Managers\AccountManager
-        arguments: [@jhg_nexmo_client]
+        arguments: ['@jhg_nexmo_client']
 
     jhg_nexmo_sms:
         class: Jhg\NexmoBundle\Managers\SmsManager
-        arguments: [@jhg_nexmo_client,"%jhg_nexmo.from_name%"]
+        arguments: ['@jhg_nexmo_client', '%jhg_nexmo.from_name%']
 
     jhg_nexmo_number:
         class: Jhg\NexmoBundle\Managers\NumberManager
-        arguments: [@jhg_nexmo_client]
+        arguments: ['@jhg_nexmo_client']


### PR DESCRIPTION
In Symfony3 and PhpUnit5, the Yaml component doesn't allow anymore to have services like `@logger` without quotes around it:

`Fatal error: Uncaught exception 'Symfony\Component\Yaml\Exception\ParseException' with message 'The reserved indicator "@" cannot start a plain scalar; you need to quote the scalar at line 4 (near "arguments: ['%jhg_nexmo.api_key%','%jhg_nexmo.api_secret%','%jhg_nexmo.api_method%','%jhg_nexmo.delivery_phone%','%jhg_nexmo.disable_delivery%',@logger]").' in phar:///usr/local/bin/phpunit/symfony/yaml/Inline.php:241`

This PR aims at fixing this issue so that we can use this nice bundle with these 2 frameworks.

Thanks!