### PR TITLE
Add message type to handle unicode messages

### DIFF
--- a/Managers/SmsManager.php
+++ b/Managers/SmsManager.php
@@ -36,12 +36,13 @@ class SmsManager
      * @param string $message
      * @param null|string $fromName
      * @param int $status_report_req
+     * @param string $type
      * @return SmsSendResponse
      */
-    public function sendText($number,$message,$fromName=null,$status_report_req=0) {
+    public function sendText($number,$message,$fromName=null,$status_report_req=0,$type='text') {
         $fromName = $fromName!==null ? $fromName : $this->defaultFromName;
         $number = PhoneNumber::prefixFilter($number);
-        $response = $this->nexmoClient->sendTextMessage($fromName,$number,$message,$status_report_req);
+        $response = $this->nexmoClient->sendTextMessage($fromName,$number,$message,$status_report_req,$type);
         return SmsSendResponse::createFromResponse($response);
     }
 

--- a/NexmoClient/NexmoClient.php
+++ b/NexmoClient/NexmoClient.php
@@ -112,10 +112,11 @@ class NexmoClient {
      * @param string $toNumber
      * @param string $text
      * @param int $status_report_req
+     * @param string $type
      * @return array
      * @throws \Exception
      */
-    public function sendTextMessage($fromName,$toNumber,$text,$status_report_req=0) {
+    public function sendTextMessage($fromName,$toNumber,$text,$status_report_req=0,$type='text') {
         $this->logger->debug("Nexmo sendTextMessage from $fromName to $toNumber with text '$text'");
 
         // delivery phone for development
@@ -129,6 +130,7 @@ class NexmoClient {
             'from'=>$fromName,
             'to'=>$toNumber,
             'text'=>$text,
+            'type' => $type,
             'status-report-req'=>$status_report_req,
         );
 


### PR DESCRIPTION
Add new parameter for the API to be able to handle different types of text message the default 'text' type is kept for backward compatibility see https://docs.nexmo.com/messaging/sms-api/api-reference for more info