### PR TITLE
Updating NexmoClient to support TLSv1.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.buildpath
 /.project
 /.idea/*
+/vendor

--- a/NexmoClient/NexmoClient.php
+++ b/NexmoClient/NexmoClient.php
@@ -1,159 +1,227 @@
 <?php
+
 namespace Jhg\NexmoBundle\NexmoClient;
 
+use Exception;
 use Jhg\NexmoBundle\NexmoClient\Exceptions\NexmoClientException;
 use Jhg\NexmoBundle\NexmoClient\Exceptions\QuotaExcededException;
 use Jhg\NexmoBundle\NexmoClient\Exceptions\UnroutableSmsMessageException;
+use NexmoClient\NexmoResponseCodes;
 use Psr\Log\LoggerInterface;
 
-class NexmoClient {
+/**
+ * Represents a client connection to the Nexmo Api.
+ *
+ * @package Jhg\NexmoBundle\NexmoClient
+ */
+class NexmoClient
+{
 
     /**
+     * The API endpoint.
+     *
      * @var string
      */
     protected $rest_url;
 
     /**
+     * A unique key that will be used to perform connections to the API.
+     *
      * @var string
      */
     protected $api_key;
 
     /**
+     * A unique password that will be used to validate the connection requested to the API.
+     *
      * @var string
      */
     protected $api_secret;
 
     /**
+     * The request method.
+     *
+     * This can be POST, GET, etc.
+     *
      * @var string
      */
     protected $api_method;
 
     /**
+     * The destination phone number.
+     *
      * @var string
      */
     protected $delivery_phone;
 
     /**
+     * A boolean representation which, when set to true, will disable the API true SMS deliver and return a debug
+     * information of the process.
+     *
+     * Defaults to false.
+     *
      * @var boolean
      */
     protected $disable_delivery;
 
     /**
+     * The Logger instance that will be used to log exception scenarios.
+     *
      * @var LoggerInterface
      */
     protected $logger;
 
     /**
-     * @param $api_key
-     * @param $api_secret
-     * @param string $api_method GET|POST configured in Nexmo API preferences
-     * @param string $delivery_phone
-     * @param boolean $disable_delivery
+     * NexmoClient constructor
+     *
+     * @param                 $api_key
+     * @param                 $api_secret
+     * @param string          $api_method GET|POST configured in Nexmo API preferences
+     * @param string          $delivery_phone
+     * @param boolean         $disable_delivery
      * @param LoggerInterface $logger
      */
-    public function __construct($api_key,$api_secret,$api_method='GET',$delivery_phone,$disable_delivery=false,LoggerInterface $logger) {
-        $this->rest_url = 'https://rest.nexmo.com';
-        $this->api_key = $api_key;
-        $this->api_secret = $api_secret;
-        $this->api_method = $api_method;
-        $this->delivery_phone = $delivery_phone;
+    public function __construct(
+        $api_key,
+        $api_secret,
+        $api_method = 'GET',
+        $delivery_phone,
+        $disable_delivery = false,
+        LoggerInterface $logger
+    ) {
+        $this->rest_url         = 'https://rest.nexmo.com';
+        $this->api_key          = $api_key;
+        $this->api_secret       = $api_secret;
+        $this->api_method       = $api_method;
+        $this->delivery_phone   = $delivery_phone;
         $this->disable_delivery = $disable_delivery;
-        $this->logger = $logger;
+        $this->logger           = $logger;
     }
 
     /**
-     * @param $url
+     * Use this method to perform a json API request for a given endpoint.
+     *
+     * @param       $url
      * @param array $params
+     *
      * @return array
      */
-    protected function jsonRequest($url,$params=array()) {
+    protected function jsonRequest($url, $params = array())
+    {
 
-        $params['api_key'] = $this->api_key;
+        $params['api_key']    = $this->api_key;
         $params['api_secret'] = $this->api_secret;
 
-        $request_url = $this->rest_url.'/'.trim($url,'/').'?'.http_build_query($params);
+        $request_url = $this->rest_url . '/' . trim($url, '/') . '?' . http_build_query($params);
 
         $request = curl_init($request_url);
-        curl_setopt($request,CURLOPT_RETURNTRANSFER,true );
-        curl_setopt($request,CURLOPT_SSL_VERIFYPEER,false);
-        curl_setopt($request, CURLOPT_HTTPHEADER,array('Accept: application/json'));
+        curl_setopt($request, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($request, CURLOPT_SSL_VERIFYPEER, true);
+        curl_setopt($request, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2);
+        curl_setopt($request, CURLOPT_HTTPHEADER, array('Accept: application/json'));
 
-        $response = curl_exec($request);
-        $curl_info = curl_getinfo($request);
+        $response           = curl_exec($request);
+        $curl_info          = curl_getinfo($request);
         $http_response_code = (int)$curl_info['http_code'];
         curl_close($request);
 
-        switch($http_response_code) {
+        switch ($http_response_code) {
             case 200:
-                return json_decode($response,true);
+                $parsedResponse = json_decode($response, true);
+                break;
+            default:
+                $parsedResponse = array(
+                    'messages' => array(
+                        array (
+                            'error-text' => "Failed HTTP error: {$http_response_code}"
+                            ,'status'    => NexmoResponseCodes::ERROR_GENERAL
+                        )
+                    )
+                );
         }
+
+        return $parsedResponse;
     }
 
 
     /**
+     * Use this method to retrieve the account balance.
+     *
      * @example {"autoReload":false,"value":0.2}
+     *
      * @return array
      */
-    public function accountBalance() {
+    public function accountBalance()
+    {
         return $this->jsonRequest('/account/get-balance');
     }
 
 
     /**
+     * Use this method to retrieve the sms pricing for a given country.
+     *
      * @param $country
+     *
      * @return array[country=ES,mt=0.060000,name=Spain,prefix=34]
      */
-    public function accountSmsPrice($country) {
-        return $this->jsonRequest('/account/get-pricing/outbound',array('country'=>$country));
+    public function accountSmsPrice($country)
+    {
+        return $this->jsonRequest('/account/get-pricing/outbound', array('country' => $country));
     }
 
     /**
+     * Use this method to send a sms message to a given destination.
+     *
      * @param string $fromName
      * @param string $toNumber
      * @param string $text
-     * @param int $status_report_req
+     * @param int    $status_report_req
+     *
      * @return array
-     * @throws \Exception
+     *
+     * @throws Exception
      */
-    public function sendTextMessage($fromName,$toNumber,$text,$status_report_req=0) {
+    public function sendTextMessage($fromName, $toNumber, $text, $status_report_req = 0)
+    {
         $this->logger->debug("Nexmo sendTextMessage from $fromName to $toNumber with text '$text'");
 
         // delivery phone for development
-        if($this->delivery_phone) {
+        if ($this->delivery_phone) {
             $toNumber = $this->delivery_phone;
 
             $this->logger->debug("Nexmo sendTextMessage delivery to $toNumber");
         }
 
         $params = array(
-            'from'=>$fromName,
-            'to'=>$toNumber,
-            'text'=>$text,
-            'status-report-req'=>$status_report_req,
+            'from'              => $fromName,
+            'to'                => $toNumber,
+            'text'              => $text,
+            'status-report-req' => $status_report_req,
         );
 
-        if($this->disable_delivery) {
+        if ($this->disable_delivery) {
             $this->logger->debug("Nexmo sendTextMessage delivery disabled by config");
+
             return array(
-                "status" => "0",
-                "message-id" => "delivery-disabled",
-                "to" => $toNumber,
-                "client-ref" => 0,
+                "status"            => "0",
+                "message-id"        => "delivery-disabled",
+                "to"                => $toNumber,
+                "client-ref"        => 0,
                 "remaining-balance" => 0,
-                "message-price" => 0,
-                "network" => 0,
+                "message-price"     => 0,
+                "network"           => 0,
             );
         }
 
-        $response = $this->jsonRequest('/sms/json',$params);
+        $response = $this->jsonRequest('/sms/json', $params);
 
-        if(0 !==  $code = (int)$response['messages'][0]['status']) {
+        if (0 !== $code = (int)$response['messages'][0]['status']) {
             $error = $response['messages'][0]['error-text'];
-            switch( $code) {
-                case 6:
+            switch ($code) {
+                case NexmoResponseCodes::ERROR_ANTI_SPAM_REJECTION:
                     throw new UnroutableSmsMessageException($error, $code);
 
-                case 9:
+                case NexmoResponseCodes::ERROR_ILLEGAL_NUMBER:
                     throw new QuotaExcededException($error, $code);
 
                 default:

--- a/NexmoClient/NexmoResponseCodes.php
+++ b/NexmoClient/NexmoResponseCodes.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * @author Cristiano Diniz da Silva <cdasilva@sonnysdirect.com>
+ */
+
+namespace NexmoClient;
+
+/**
+ * Describe a list of Response Codes that are returned by the API.
+ *
+ * @package NexmoClient
+ */
+final class NexmoResponseCodes
+{
+
+    /**
+     * Represents a message that was successfully delivered.
+     */
+    const DELIVERED_RESPONSE = 0;
+
+    /**
+     * Represents a message that either: An unknown error was received from the carrier who tried to send this this
+     * message. Depending on the carrier, that to is unknown. When you see this error, and status is rejected, always
+     * check if to in your request was valid.
+     */
+    const ERROR_UNKNOWN = 1;
+
+    /**
+     * Represents a message that was not delivered because to was temporarily unavailable. For example, the handset
+     * used for to was out of coverage or switched off. This is a temporary failure, retry later for a positive result.
+     */
+    const ERROR_ABSENT_SUBSCRIBER_TEMPORARY = 2;
+
+    /**
+     * Represents a message that the subscriber is no longer active, you should remove this phone number from your
+     * database.
+     */
+    const ERROR_ABSENT_SUBSCRIBER_PERMANENT = 3;
+
+    /**
+     * Represents a message/call that is being blocked by the user. The only way to receive messages/calls is if the
+     * user contacts the carrier.
+     */
+    const ERROR_CALL_BARRED_BY_USER = 4;
+
+    /**
+     * Represents a message/call that can't be received by the user because the portability from a carrier to another
+     * was not properly done.
+     */
+    const ERROR_PORTABILITY = 5;
+
+    /**
+     * Represents a message/call that can't be delivered because the carrier pushed it into anti-spam.
+     */
+    const ERROR_ANTI_SPAM_REJECTION = 6;
+
+    /**
+     * Represents a message/call that couldn't be delivered because the handset associated with to was not available
+     * when this message was sent. If status is Failed, this is a temporary failure; retry later for a positive result.
+     * If status is Accepted, this message has is in the retry scheme and will be resent until it expires in 24-48
+     * hours.
+     */
+    const ERROR_HANDSET_BUSY = 7;
+
+    /**
+     * A network failure while sending your message. This is a temporary failure, retry later for a positive result.
+     */
+    const ERROR_NETWORK = 8;
+
+    /**
+     * Represents a message that was attempted to be sent to a user that has already opted out. Blacklisted.
+     */
+    const ERROR_ILLEGAL_NUMBER = 9;
+
+    /**
+     * The message could not be sent because one of the parameters in the message was incorrect. For example, incorrect
+     * type or udh.
+     */
+    const ERROR_INVALID_MESSAGE = 10;
+
+    /**
+     * There is an API routing issue. Contact Nexmo.
+     */
+    const ERROR_UNROUTABLE = 11;
+
+    /**
+     * Represents a message that could not be delivered to the phone number.
+     */
+    const ERROR_DESTINATION_UNREACHABLE = 12;
+
+    /**
+     * Represents a message/call that the carrier blocked this message because the content is not suitable for to based
+     * on age restrictions.
+     */
+    const ERROR_SUBSCRIBER_AGE_RESTRICTION = 13;
+
+    /**
+     * Represents a message/call that the carrier blocked this message. This could be due to several reasons. For
+     * example, to's plan does not include SMS or the account is suspended.
+     */
+    const ERROR_NUMBER_BLOCKED_BY_CARRIER = 14;
+
+    /**
+     * Represents a message/call that could not be delivered because of insufficient funds. To’s pre-paid account does
+     * not have enough credit to receive the message.
+     */
+    const ERROR_PREPAID_INSUFFICIENT_FUNDS = 15;
+
+    /**
+     * There is an API issue. Contact Nexmo.
+     */
+    const ERROR_GENERAL = 99;
+}


### PR DESCRIPTION
In Early May of 2018, Nexmo send out a letter to all customers where they were discontinuing the support for TLSv1 and TLSv1.1 protocols. The decision was made in respect and to protect customer data following the payment card industry security council suggestions (PCI SSC).

On May 28th the protocol is finally being moved to TLSv1.2 and the discontinuation of prior versions of TLS is finalized.

During initial testing was found that, although CURL supports TLS negotiation, depending of the version of the system that it is being used, the negotiation could result in a unknown cypher which would result in returning a protocol that is not the expected TLSv1.2.

To fully support this migration the following changes were made:

1 - enforce CURL SSL version to use TLSv1.2
2 - enforce CURL to verify the SSL peer.

With this commit a few improvements has been made:

1 - Documentation on the NexmoClient Class
2 - Improved the jsonRequest function from NexmoClient to always return an array, following documentation, which would require an error to be returned if the http response code was not 200.
3 - Adding the vendor directory into the gitignore file
4 - Creation and use of a NexmoResponseCode class that will have every possible response code that is returned from the Nexmo API. The goal of the class is to ensure clarity.